### PR TITLE
chore: change maven groupId to org.hisp.dhis.integration.sdk

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,13 +4,14 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>org.example</groupId>
+    <groupId>org.hisp.dhis.integration.sdk</groupId>
     <artifactId>dhis2-java-sdk</artifactId>
     <version>1.0.0-SNAPSHOT</version>
 
     <properties>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
+        <jackson.version>2.13.2</jackson.version>
     </properties>
 
     <build>
@@ -148,12 +149,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.13.2</version>
+            <version>${jackson.version}</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-jdk8</artifactId>
-            <version>2.13.2</version>
+            <version>${jackson.version}</version>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>


### PR DESCRIPTION
## Summary

* [x] Change maven groupId from `org.example` to `org.hisp.dhis.integration.sdk`
